### PR TITLE
call super in addon#init

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ var VersionChecker = require('ember-cli-version-checker');
 module.exports = {
   name: 'ember-hash-helper-polyfill',
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
+
     var checker = new VersionChecker(this);
     this._checkerForEmber = checker.for('ember', 'bower');
   },


### PR DESCRIPTION
Fixes deprecation warnings in ember-cli 2.6
