### PR TITLE
Update ember-cli-version-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^6.8.2",
-    "ember-cli-version-checker": "^1.2.0"
+    "ember-cli-version-checker": "^2.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This update is a prerequisite for using ember-cli with yarn workspaces.